### PR TITLE
Fix sort by status

### DIFF
--- a/www/assets/components/virtunewsletter/js/mgr/widgets/grid.reports.js
+++ b/www/assets/components/virtunewsletter/js/mgr/widgets/grid.reports.js
@@ -32,10 +32,13 @@ VirtuNewsletter.grid.Reports = function(config) {
                 sortable: true
             }, {
                 header: _('virtunewsletter.status'),
-                dataIndex: 'status_text',
+                dataIndex: 'status',
                 sortable: true,
                 width: 80,
-                fixed: true
+                fixed: true,
+                renderer: function(value, metaData, record, row, col, store, gridView){
+                    return record.data.status_text;
+                }
             }, {
                 header: _('virtunewsletter.created_on'),
                 dataIndex: 'status_logged_on',


### PR DESCRIPTION
When trying to sort by status in reports nothing is returned because there is no "status_text" column.